### PR TITLE
build(lint): add commit scope-enum and fix Dependabot commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,7 @@ updates:
     assignees:
       - "ExaDev"
     commit-message:
-      # "deps"/"deps-dev" are not conventional-commit types; commitlint's type-enum (derived from release.config.ts) would reject every Dependabot commit otherwise.
-      prefix: "chore"
-      prefix-development: "chore"
-      include: "scope"
+      prefix: "build(deps)"
     groups:
       # Group patch updates together
       patch-updates:
@@ -57,8 +54,7 @@ updates:
     assignees:
       - "ExaDev"
     commit-message:
-      prefix: "ci"
-      include: "scope"
+      prefix: "ci(deps)"
     groups:
       # Group all GitHub Actions updates together
       github-actions:

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -5,5 +5,5 @@ if grep -qi "^Claude-Session:" "$1"; then
   exit 1
 fi
 
-# Enforce conventional-commit message format, with the allowed type list derived from .releaserc.json.
+# Enforce conventional-commit message format, with the allowed type list derived from release.config.ts.
 NODE_OPTIONS="--experimental-strip-types" pnpm exec commitlint --edit "$1"

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -21,13 +21,13 @@ This project uses [semantic-release](https://semantic-release.gitbook.io/) with 
 
 ## Configuration Files
 
-### `.releaserc.json`
+### `release.config.ts`
 
 - Main semantic-release configuration
 - Defines plugins and rules for version analysis
 - Configures changelog generation
 
-### `.commitlintrc.json`
+### `commitlint.config.ts`
 
 - Validates commit message format
 - Enforces conventional commit standards

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -9,6 +9,37 @@ const Configuration: UserConfig = {
     "subject-empty": [2, "never"],
     "subject-full-stop": [2, "never", "."],
     "header-max-length": [2, "always", 100],
+    "scope-enum": [
+      2,
+      "always",
+      [
+        // Interfaces (src/api-server.ts, src/cli.ts, src/mcp-server.ts, src/index.ts)
+        "api",
+        "cli",
+        "mcp",
+        "index",
+        // src/ module directories
+        "commands",
+        "core",
+        "generated",
+        "integration",
+        "schemas",
+        "scripts",
+        "strategies",
+        "types",
+        "utils",
+        // Non-src areas
+        "docs",
+        "examples",
+        // Tooling and process
+        "build",
+        "ci",
+        "deps",
+        "deps-dev",
+        "lint",
+        "release",
+      ],
+    ],
   },
 };
 


### PR DESCRIPTION
## Summary

Fixes three gaps against plan step 10 (from the devops-normalize-markmv effort, merged in #93) that were reported complete but weren't fully landed:

- `commitlint.config.ts` had no `scope-enum` rule at all.
- `.github/dependabot.yml` still used the old `chore`/`ci` + `include: scope` convention instead of `build(deps)`/`ci(deps)` prefixes matching the new scope-enum.
- `.husky/commit-msg`'s comment and `VERSIONING.md`'s configuration-files section still named `.releaserc.json`/`.commitlintrc.json`, both renamed to `release.config.ts`/`commitlint.config.ts` in #93.

## Test plan

- [x] `pnpm run lint` / `typecheck` / `build` / `knip` / `test:run` all pass locally
- [x] Verified `build(deps): bump zod from 4.4.3 to 4.5.0` and `ci(deps): bump actions/checkout from 6 to 7` both pass commitlint under the new scope-enum
- [ ] CI green on this PR