### PR TITLE
ci: have Dependabot also scan the composite action's own directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,10 @@ updates:
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # Dependabot's file fetcher only looks for action.yml/action.yaml inside a configured directory itself, it does not walk into subdirectories of "/" looking for composite actions -- the pins inside .github/actions/setup/action.yml (pnpm/action-setup, actions/setup-node, actions/cache) need their own directory entry or Dependabot never proposes a bump for them at all.
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary

Dependabot's github-actions ecosystem block only covered `directory: "/"`, so pins inside `.github/actions/setup/action.yml` (pnpm/action-setup, actions/setup-node, actions/cache) never got a bump proposed -- confirmed live via PR #98's title only listing "1 directory". Add `/.github/actions/*` as a second scanned directory, matching agent-permissions-spec's own dependabot.yml.

## Test plan

- [x] `pnpm run lint` passes
- [ ] CI green on this PR
- [ ] GitHub accepts the dependabot.yml schema (its own automatic validation workflow)